### PR TITLE
golioth-observe: uint8_t* instead of uint8_t

### DIFF
--- a/website/docs/zephyr-intro/zephyr-examples/golioth-observe.md
+++ b/website/docs/zephyr-intro/zephyr-examples/golioth-observe.md
@@ -115,10 +115,10 @@ The endpoints that send data to either LightDB State or LightDB stream differ by
 
 ```c
 /* These two lines evaluate to the same string */
-uint8_t state_endpoint_1 = GOLIOTH_LIGHTDB_PATH("leds");
-uint8_t state_endpoint_2 = ".d/leds";
+uint8_t* state_endpoint_1 = GOLIOTH_LIGHTDB_PATH("leds");
+uint8_t* state_endpoint_2 = ".d/leds";
 
 /* These two lines also evaluate to the same string */
-uint8_t stream_endpoint_1 = GOLIOTH_LIGHTDB_STREAM_PATH("accel");
-uint8_t stream_endpoint_2 = ".s/accel";
+uint8_t* stream_endpoint_1 = GOLIOTH_LIGHTDB_STREAM_PATH("accel");
+uint8_t* stream_endpoint_2 = ".s/accel";
 ```


### PR DESCRIPTION
Example code fix discovered by a trainee.

Signed-off-by: Nick Miller <nick@golioth.io>