### PR TITLE
Remove branch change and OVERLAY_CONF instructions

### DIFF
--- a/website/docs/golioth-exercises/compile-golioth-demo.md
+++ b/website/docs/golioth-exercises/compile-golioth-demo.md
@@ -31,12 +31,10 @@ We are doing this so you can use this hardware and firmware on the MagTag to exp
 ### Build in the KASM container
 
 1. In the KASM container, go to your local copy of [the magtag-demo
-   repository](https://github.com/golioth/magtag-demo) and ensure you are on the
-   `main` branch which is the hello example
+   repository](https://github.com/golioth/magtag-demo).
 
     ```bash
     cd ~/Desktop/magtag-training/app
-    git checkout golioth-demo
     ```
 
 2. Create a file for WiFi and Golioth credentials
@@ -55,7 +53,7 @@ We are doing this so you can use this hardware and firmware on the MagTag to exp
 3. Build the example, including the credentials file you just created
 
     ```bash
-    west build -b esp32s2_saola . -D OVERLAY_CONFIG=credentials.conf -p
+    west build -b esp32s2_saola golioth-demo -p
     ```
 
 4. Download the binary

--- a/website/docs/sensor-exercises/sensor-dps310.md
+++ b/website/docs/sensor-exercises/sensor-dps310.md
@@ -53,7 +53,7 @@ esp32s2_saola dts file:
 };
 ```
 
-Two important things to not from the node above: there is no status listed which
+Two important things to note from the node above: there is no status listed which
 means the peripheral is not enabled, and the pinctrl-0 entry tells us to look
 for the `i2c1_default` node in the pinctrl.dtsi file to see how the pins are
 mapped and configured:
@@ -200,17 +200,22 @@ DPS310](https://github.com/zephyrproject-rtos/zephyr/tree/main/samples/sensor/dp
 is available in Zephyr. It is nearly identical to the code outlined above. As an
 exercise:
 
-1. Make a copy of the code sample into your
-   `golioth-zephyr-workspace/modules/lib/golioth/samples/` folder
+1. Make a copy of the code sample into your `app` directory:
+
+    ```
+    cd ~/magtag-training/app
+    cp -r ../deps/zephyr/samples/sensor/dps310
+    ```
+
 2. Study the `app.overlay` file from the sample and compare it to the `*dev`
 assignment in `main.c`.
     * Notice the different approach that was taken by the sample writers from
       what is outlined above. There is more than one way to get information from
       the Devicetree.
-3. Remove the `app.overlay` file, add a `boards` directory and place your
+3. Remove the `app.overlay` file and add a `boards` directory. Place your
 `esp32s2_saola.overlay` file inside with the Devicetree entries as shown above.
-Alter `main.c` to work with the way your overlay file defines the sensor.
-4. Build, flash, and run the sample. Verify it is printing pressure and
+4. Alter `main.c` to work with the way your overlay file defines the sensor.
+5. Build, flash, and run the sample. Verify it is printing pressure and
 temperature data to the serial console.
 
 ### Exercise: Stream DPS310 Data to Golioth LightDB

--- a/website/docs/zephyr-intro/zephyr-examples/blinky.md
+++ b/website/docs/zephyr-intro/zephyr-examples/blinky.md
@@ -26,17 +26,16 @@ Blinky shows that your toolchain is capable of building code correctly, that you
 
 ### Build in the KASM container
 
-1. In the KASM container, go to your local copy of [the magtag-demo repository](https://github.com/golioth/magtag-demo) and checkout the `blinky` example:
+1. In the KASM container, go to your local copy of [the magtag-demo repository](https://github.com/golioth/magtag-demo).
 
     ```bash
     cd ~/Desktop/magtag-training/app
-    git checkout blinky
     ```
 
 2. Build the example
 
     ```bash
-    west build -b esp32s2_saola . -p
+    west build -b esp32s2_saola blinky -p
     ```
 
 3. Download the binary

--- a/website/docs/zephyr-intro/zephyr-examples/golioth-hello.md
+++ b/website/docs/zephyr-intro/zephyr-examples/golioth-hello.md
@@ -25,11 +25,10 @@ The Hello example is the most basic network-connected example: a 'hello world' w
 
 ### Build in the KASM container
 
-1. In the KASM container, go to your local copy of [the magtag-demo repository](https://github.com/golioth/magtag-demo) and ensure you are on the `main` branch which is the hello example
+1. In the KASM container, go to your local copy of [the magtag-demo repository](https://github.com/golioth/magtag-demo).
 
     ```bash
     cd ~/Desktop/magtag-training/app
-    git checkout main
     ```
 
 2. Create a file for WiFi and Golioth credentials
@@ -46,7 +45,7 @@ The Hello example is the most basic network-connected example: a 'hello world' w
 3. Build the example, including the credentials file you just created
 
     ```bash
-    west build -b esp32s2_saola . -D OVERLAY_CONFIG=credentials.conf -p
+    west build -b esp32s2_saola hello -p
     ```
 
 4. Download the binary

--- a/website/docs/zephyr-intro/zephyr-examples/golioth-observe.md
+++ b/website/docs/zephyr-intro/zephyr-examples/golioth-observe.md
@@ -25,17 +25,16 @@ We are learning to use the "state" version of Golioth's database services (Light
 
 ### Time Estimate
 
-* 15 minutes 
+* 15 minutes
 
 ## Workflow
 
 ### Build in the KASM container
 
-1. In the KASM container, go to your local copy of [the magtag-demo repository](https://github.com/golioth/magtag-demo) and checkout the `observe` example:
+1. In the KASM container, go to your local copy of [the magtag-demo repository](https://github.com/golioth/magtag-demo).
 
     ```bash
     cd ~/magtag-training/app
-    git checkout observe
     ```
 2. Create a file for WiFi and Golioth credentials
 
@@ -44,7 +43,7 @@ We are learning to use the "state" version of Golioth's database services (Light
 3. Build the example, including the credentials file you just created
 
     ```bash
-    west build -b esp32s2_saola . -D OVERLAY_CONFIG=credentials.conf -p
+    west build -b esp32s2_saola observe -p
     ```
 
 4. Download the binary

--- a/website/docs/zephyr-intro/zephyr-examples/golioth-stream.md
+++ b/website/docs/zephyr-intro/zephyr-examples/golioth-stream.md
@@ -32,12 +32,10 @@ We want to understand time-series data and how to interact with it in Zephyr.
 ### Build in the KASM container
 
 1. In the KASM container, go to your local copy of [the magtag-demo
-   repository](https://github.com/golioth/magtag-demo) and checkout the `stream`
-   example:
+   repository](https://github.com/golioth/magtag-demo).
 
     ```bash
     cd ~/magtag-training/app
-    git checkout stream
     ```
 
 2. Create a file for WiFi and Golioth credentials
@@ -47,7 +45,7 @@ We want to understand time-series data and how to interact with it in Zephyr.
 3. Build the example, including the credentials file you just created
 
     ```bash
-    west build -b esp32s2_saola . -D OVERLAY_CONFIG=credentials.conf -p
+    west build -b esp32s2_saola stream -p
     ```
 
 4. Download the binary

--- a/website/docs/zephyr-intro/zephyr-examples/zephyr-examples.md
+++ b/website/docs/zephyr-intro/zephyr-examples/zephyr-examples.md
@@ -11,4 +11,4 @@ The code examples take trainees through the basics of using the Golioth platform
 
 ## Logistics
 
-You will be going through the exercises below and then switching to different branches in the MagTag repo. Your credentials file will remain. If you are newer to revision control and development branches using Git, feel free to reach out to the instructors (or the forum, for those taking this training asynchronously).
+You will be going through the exercises below using the MagTag repo. Your credentials file can remain the same for all examples.


### PR DESCRIPTION
When the MagTag-demo code was updated for Golioth v0.3.1, it changed from using feature branches for the different demos, to including each of them as a subfolder. This commit removes the commands used to switch branches, and updates the flashing commands to point at the subfolders.

The credentails.conf file is now included in the build by default. This commit removes the command that was previously used to build in that file.

Signed-off-by: Mike Szczys <mike@golioth.io>