### PR TITLE
After training updates

### DIFF
--- a/website/docs/_partials/flash-the-example-kasm-verbose.md
+++ b/website/docs/_partials/flash-the-example-kasm-verbose.md
@@ -15,7 +15,8 @@ import TabItem from '@theme/TabItem';
   groupId="os"
   defaultValue="linux"
   values={[
-  {label: 'Linux/MacOS', value: 'linux'},
+  {label: 'MacOS', value: 'linux'},
+  {label: 'MacOS', value: 'macos'},
   {label: 'Windows', value: 'windows'},
   ]}>
 
@@ -24,6 +25,14 @@ import TabItem from '@theme/TabItem';
   ```
   cd ~/Downloads
   esptool.py --chip esp32s2 --port /dev/ttyACM0 write_flash 0x0 merged_<appfolder>_<hhmmss>.bin
+  ```
+
+  </TabItem>
+  <TabItem value="macos">
+
+  ```
+  cd ~/Downloads
+  esptool.py --chip esp32s2 --port /dev/cu.usbmodem01 write_flash 0x0 merged_<appfolder>_<hhmmss>.bin
   ```
 
   </TabItem>

--- a/website/docs/_partials/flash-the-example-kasm.md
+++ b/website/docs/_partials/flash-the-example-kasm.md
@@ -9,7 +9,8 @@ import VerbostDownloadFlash from './flash-the-example-kasm-verbose.md';
   groupId="os"
   defaultValue="linux"
   values={[
-  {label: 'Linux/MacOS', value: 'linux'},
+  {label: 'MacOS', value: 'linux'},
+  {label: 'MacOS', value: 'macos'},
   {label: 'Windows', value: 'windows'},
   ]}>
 
@@ -18,6 +19,14 @@ import VerbostDownloadFlash from './flash-the-example-kasm-verbose.md';
   ```
   cd ~/Downloads
   esptool.py --chip esp32s2 --port /dev/ttyACM0 write_flash 0x0 merged_<appfolder>_<hhmmss>.bin
+  ```
+
+  </TabItem>
+  <TabItem value="macos">
+
+  ```
+  cd ~/Downloads
+  esptool.py --chip esp32s2 --port /dev/cu.usbmodem01 write_flash 0x0 merged_<appfolder>_<hhmmss>.bin
   ```
 
   </TabItem>

--- a/website/docs/after-training/local-toolchain-install.md
+++ b/website/docs/after-training/local-toolchain-install.md
@@ -13,6 +13,15 @@ to give Zephyr another try?
 
 Here are some options for installing a local version of Zephyr.
 
+:::tip Install the Zephyr SDK
+
+In all cases, you must have the Zephyr SDK bundle installed. If you have not yet
+done so, please [use this section of the Zephyr getting-started
+guide](https://docs.zephyrproject.org/latest/develop/getting_started/index.html#install-zephyr-sdk)
+before continuing with the steps below.
+
+:::
+
 * Option A: [Use the MagTag repo as a Zephyr installation](#magtag-zephyr)
 * Option B: [Follow the Golioth Quickstart to install Zephyr](#golioth-zephyr)
 * Option C: [Follow the Zephyr Getting Started Guide to install Zephyr](#standard-zephyr)

--- a/website/docs/after-training/magtag-nametag.md
+++ b/website/docs/after-training/magtag-nametag.md
@@ -95,13 +95,15 @@ four buttons will cycle through different display layouts.
 If you choose "NO" at boot time, the name tag will enter into display mode using
 stored information, and once again the layout may be chosen with the buttons.
 
-:::note Persistent storage coming soon
+:::note Persistent storage
 
-At this time, name information downloaded from Golioth will be lost between
-power cycles. However, it is possible to store persistent settings using the
-Zephyr Settings subsystem. This feature will be available soon.
+Name information downloaded from Golioth should be stored in persistent memory.
+This works if you compile and flash this app from your local machine. However,
+if you compile on KASM then download and flash a merged binary, this does not
+currently work.
 
-**Pro-level challenge:** Add persistent storage and submit a pull request!
+**Pro-level challenge:** Debug the persistent storage issue. We'd
+love to see you submit a pull request!
 
 :::
 


### PR DESCRIPTION
* Update local repo install with a note about Zephyr SDK
* Update kasm flash instructions with correct MacOS port
* Update note about nametag persistent storage