### PR TITLE
nRF Connect Install: add installation tips

### DIFF
--- a/website/docs/golioth-exploration/01-golioth-intro/_partials/install_nrf_connect.md
+++ b/website/docs/golioth-exploration/01-golioth-intro/_partials/install_nrf_connect.md
@@ -2,7 +2,22 @@
    Desktop](https://www.nordicsemi.com/Products/Development-tools/nRF-Connect-for-desktop)
    software.
 
+   1. **Mac and Linux Users:** According to [the Nordic install
+      instructions](https://infocenter.nordicsemi.com/index.jsp?topic=/struct_nrftools/struct/nrftools_nrfconnect.html)
+      you also need to [install the SEGGER J-Link
+      tools](https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack)
+
+      **MAC M1 Users:** Our testing found that you must use the `Universal
+      Installer` version of the SEGGER tools
+
 2. Launch nRF Connect for Desktop. From that application, install and open the
    Programmer.
 
-    ![Nordic nRF Connect for Desktop launch the Programmer](../assets/nrf-connect-desktop-programmer-launch.jpg)
+   ![Nordic nRF Connect for Desktop launch the Programmer](../assets/nrf-connect-desktop-programmer-launch.jpg)
+
+   :::caution Plug in and turn on your board
+
+   Plug a USB cable into the USB port closest to the power switch on your board.
+   Make sure the power switch is in the `ON` position.
+
+   :::


### PR DESCRIPTION
* Linux and Mac must install SEGGER tools
* You must plug in and turn on the board