### PR TITLE
Use relative path for submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "submodule-goliothdocs"]
 	path = submodule-goliothdocs
-	url = https://github.com/golioth/docs.git
+	url = ../docs.git


### PR DESCRIPTION
This will automatically select ssh or https auth for the submodule to match what was used when checking out the parent repo.

After pulling this change, you can update your submodule URL in your clone by running `git submodule sync` but it's not necessary if you're happy with https auth.