### PR TITLE
Swap the order of the Zephyr Training vs. API Training modules

### DIFF
--- a/website/docs/golioth-exploration/03-next-steps.md
+++ b/website/docs/golioth-exploration/03-next-steps.md
@@ -9,10 +9,10 @@ description: |
 Thank you for learning about Golioth! From here, move on to the module that
 matches your training session today:
 
-## [Golioth API Training](/docs/api-training)
-
-Learn how to access data and control fleet devices using the Golioth REST APIs.
-
 ## [Zephyr Training](/docs/zephyr-training)
 
 Wrap your head around Zephyr with this quickstart training.
+
+## [Golioth API Training](/docs/api-training)
+
+Learn how to access data and control fleet devices using the Golioth REST APIs.

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -64,15 +64,15 @@ const config = {
             position: 'left',
           },
           {
-            to: 'docs/api-training',
-            activeBasePath: 'api-training',
-            label: 'API Training',
-            position: 'left',
-          },
-          {
             to: 'docs/zephyr-training',
             activeBasePath: 'zephyr-training',
             label: 'Zephyr Training',
+            position: 'left',
+          },
+          {
+            to: 'docs/api-training',
+            activeBasePath: 'api-training',
+            label: 'API Training',
             position: 'left',
           },
           {

--- a/website/src/components/HomepageFeatures.js
+++ b/website/src/components/HomepageFeatures.js
@@ -18,19 +18,6 @@ const FeatureList = [
     ),
   },
   {
-    title: 'Golioth REST API Training',
-    link: '/docs/api-training',
-    description: (
-      <>
-        Golioth makes it easy to interact with your IoT devices and their data.
-        This REST API training module will familiarize you with how devices are
-        represented in the cloud. You'll learn how monitor and control your
-        fleet, and access the time-series and stateful data being collected from
-        it.
-      </>
-    ),
-  },
-  {
     title: 'Zephyr Training',
     link: '/docs/zephyr-training',
     img: require('../../static/img/Zephyr_logo_300x300.png'),
@@ -41,6 +28,19 @@ const FeatureList = [
         company projects. After getting started quickly, users will learn how to
         properly set up a Zephyr project and be ready to deploy a professional
         project.
+      </>
+    ),
+  },
+  {
+    title: 'Golioth REST API Training',
+    link: '/docs/api-training',
+    description: (
+      <>
+        Golioth makes it easy to interact with your IoT devices and their data.
+        This REST API training module will familiarize you with how devices are
+        represented in the cloud. You'll learn how monitor and control your
+        fleet, and access the time-series and stateful data being collected from
+        it.
       </>
     ),
   },


### PR DESCRIPTION
Swap the order of the Zephyr Training vs. API Training modules to match the sequence of the live training. In the live trainings, we skip the "API Training" module, but in the past a couple people have been confused because they went straight from the "Intro to Golioth" to the next module which is "API Training".