### PR TITLE
hardware setup: recommend windows users install SEGGER

### DIFF
--- a/website/docs/golioth-exploration/01-golioth-intro/_partials/install_nrf_connect.md
+++ b/website/docs/golioth-exploration/01-golioth-intro/_partials/install_nrf_connect.md
@@ -28,12 +28,22 @@ import TabItem from '@theme/TabItem';
     </TabItem>
     <TabItem value="windows">
 
-    **Windows Users** have reported that you should select "Install legacy USB
-    Driver for J-Link" during the Segger J-Link installation step of the wizard.
-    Some users are unable to connect to the dev board when this driver is not
-    installed.
+    1. Install newer SEGGER Tools
 
-    ![Segger install wizard options](./assets/install_nrf_segger_windows.png)
+        **Windows Users** have reported that the version of the SEGGER tools
+        included with nRF Connect for Desktop may be too old to offer the legacy
+        driver installation option and suggest installing the [newest version
+        available directly from
+        SEGGER](https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack).
+
+    2. Select legacy USB drivers during SEGGER install
+
+        **Windows Users** have reported that you should select "Install legacy
+        USB Driver for J-Link" during the Segger J-Link installation step of the
+        wizard. Some users are unable to connect to the dev board when this
+        driver is not installed.
+
+        ![Segger install wizard options](./assets/install_nrf_segger_windows.png)
     </TabItem>
     </Tabs>
 


### PR DESCRIPTION
Users reported that the version of SEGGER tools delivered with nRF Connect for Desktop doesn't offer the legacy USB driver installation option. This updates the guide to recommend installing those tools direct from SEGGER.

resolves #89
resolves https://github.com/golioth/devrel-issue-tracker/issues/414