### PR TITLE
Fix: Use `strlen` for JSON message in LightDB example

### DIFF
--- a/website/docs/zephyr-training/05_golioth/lightdb_stream.md
+++ b/website/docs/zephyr-training/05_golioth/lightdb_stream.md
@@ -85,7 +85,7 @@ Excerpts from `main.c`:
 					 "sensor",
 					 GOLIOTH_CONTENT_TYPE_JSON,
 					 sbuf,
-					 sizeof(sbuf),
+					 strlen(sbuf),
 					 NULL,
 					 NULL);
         // highlight-end


### PR DESCRIPTION
`sizeof` gives the wrong value and so the JSON will be mangled. Using `strlen` sends the whole string which makes this example work.