### PR TITLE
Remove /docs/ prefix from urls

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -6,6 +6,13 @@
       "firebase.json",
       "**/.*",
       "**/node_modules/**"
+    ],
+    "redirects": [
+      {
+        "source": "/docs/:urlpath*",
+        "destination": "/:urlpath",
+        "type": 301
+      }
     ]
   }
 }

--- a/website/docs/api-training/README.md
+++ b/website/docs/api-training/README.md
@@ -34,7 +34,7 @@ every way necessary for your business.
 
 :::tip Prerequisites
 
-You must complete the [**Intro to Golioth**](/docs/golioth-exploration) section
+You must complete the [**Intro to Golioth**](/golioth-exploration) section
 prior to beginning the API Training module. This module utilizes the device you
 set up during the exploration to learn about data monitoring and fleet control.
 

--- a/website/docs/golioth-exploration/01-golioth-intro/03-hardware-setup.md
+++ b/website/docs/golioth-exploration/01-golioth-intro/03-hardware-setup.md
@@ -94,9 +94,9 @@ Zephyr.
     :::info
 
     Golioth Device Credentials were created during the [Console Signup and
-    Exploration](/docs/golioth-exploration/golioth-intro/golioth-console) step.
-    You can return to the [Golioth Console](https://console.golioth.io/) to
-    retrieve the PSK-ID/PSK.
+    Exploration](/golioth-exploration/golioth-intro/golioth-console) step. You
+    can return to the [Golioth Console](https://console.golioth.io/) to retrieve
+    the PSK-ID/PSK.
 
     WiFi credentials come from your home or business WiFi. It is also possible
     to use your phone as a WiFi hotspot.
@@ -175,9 +175,9 @@ properly. This is accomplished over USB using the Shell built into Zephyr.
     :::info
 
     Golioth Device Credentials were created during the [Console Signup and
-    Exploration](/docs/golioth-exploration/golioth-intro/golioth-console) step.
-    You can return to the [Golioth Console](https://console.golioth.io/) to
-    retrieve the PSK-ID/PSK.
+    Exploration](/golioth-exploration/golioth-intro/golioth-console) step. You
+    can return to the [Golioth Console](https://console.golioth.io/) to retrieve
+    the PSK-ID/PSK.
 
     :::
 

--- a/website/docs/zephyr-training/01_What_is_Zephyr/README.md
+++ b/website/docs/zephyr-training/01_What_is_Zephyr/README.md
@@ -69,4 +69,4 @@ In this module we'll learn about the various parts that make up Zephyr:
 In the next few pages we will learn about the main parts that make up a Zephyr
 project. It's good to have an understanding of this to understand how your
 builds work. However, we'll hold off on the hands-on activities until we reach
-the [Build Your First Zephyr App section](/docs/zephyr-training/helloworld).
+the [Build Your First Zephyr App section](/zephyr-training/helloworld).

--- a/website/docs/zephyr-training/01_What_is_Zephyr/cmake.md
+++ b/website/docs/zephyr-training/01_What_is_Zephyr/cmake.md
@@ -41,7 +41,7 @@ allows code to be conditionally included in a build.
 :::tip Examples of conditional file inclusion
 
 The `01_IOT` application you loaded as a precompiled binary during the [Intro to
-Golioth](/docs/golioth-exploration) section demonstrates two approaches to
+Golioth](/golioth-exploration) section demonstrates two approaches to
 conditional inclusion of files:
 
 * only include a WiFi helper file if we're building for the nRF7002

--- a/website/docs/zephyr-training/01_What_is_Zephyr/kconfig.md
+++ b/website/docs/zephyr-training/01_What_is_Zephyr/kconfig.md
@@ -24,7 +24,7 @@ application.
 ![Typical file tree for a Zephyr application](./assets/typical_tree_for_zephyr_application.jpg)
 
 For example, here is the `prj.conf` file from the `01_IOT` application that you
-ran as a precompiled binary in the [Intro to Golioth](/docs/golioth-exploration)
+ran as a precompiled binary in the [Intro to Golioth](/golioth-exploration)
 section.
 
 ```

--- a/website/docs/zephyr-training/02_helloworld/convert_to_logging.md
+++ b/website/docs/zephyr-training/02_helloworld/convert_to_logging.md
@@ -338,7 +338,7 @@ You can immediately see some of the benefits provided by logging:
 :::tip Example of Golioth Remote Logging
 
 In the precompiled binary we loaded during the [Intro to
-Golioth](/docs/golioth-exploration) we observed logs being sent to the Golioth
+Golioth](/golioth-exploration) we observed logs being sent to the Golioth
 servers.
 
 The Golioth Firmware SDK implements a backend for the Zephyr Logging system to

--- a/website/docs/zephyr-training/02_helloworld/install_nrf_connect_desktop.md
+++ b/website/docs/zephyr-training/02_helloworld/install_nrf_connect_desktop.md
@@ -15,7 +15,7 @@ device and establish a serial connection with it.
 
 :::tip Have You Already Done This Step?
 
-If you completed the [**Intro to Golioth** module](/docs/golioth-exploration)
+If you completed the [**Intro to Golioth** module](/golioth-exploration)
 then you have already installed these tools. Please move on to the next page.
 
 :::

--- a/website/docs/zephyr-training/04_blinkRTOS/blink_with_thread.md
+++ b/website/docs/zephyr-training/04_blinkRTOS/blink_with_thread.md
@@ -164,10 +164,10 @@ Equally important is that your thread do something that yields back (usually
 :::tip Example of Threads and resource control
 
 The `01_IOT` precompiled binary you tested during the [Intro to
-Golioth](/docs/golioth-exploration) section uses a thread to blink the LED. One
-thing to keep in mind when accessing system resources from different threads is
-that only one thread at a time should be operating on that resource. The example
-code [uses a
+Golioth](/golioth-exploration) section uses a thread to blink the LED. One thing
+to keep in mind when accessing system resources from different threads is that
+only one thread at a time should be operating on that resource. The example code
+[uses a
 mutex](https://docs.zephyrproject.org/latest/kernel/services/synchronization/mutexes.html)
 to test for GPIO availability.
 

--- a/website/docs/zephyr-training/05_golioth/lightdb_stream.md
+++ b/website/docs/zephyr-training/05_golioth/lightdb_stream.md
@@ -184,8 +184,7 @@ not connecting to Golioth, you can check the stored PSK-ID setting by issuing
 the `settings get golioth/psk-id` command in the serial shell.
 
 Instructions for setting device credentials are available in the [Connect
-Hardware to Golioth](/docs/golioth-exploration/golioth-intro/hardware-setup)
-section.
+Hardware to Golioth](/golioth-exploration/golioth-intro/hardware-setup) section.
 
 :::
 

--- a/website/docs/zephyr-training/README.md
+++ b/website/docs/zephyr-training/README.md
@@ -36,7 +36,7 @@ directly apply to application development for your business.
 
 :::tip Prerequisites
 
-You must complete the [**Intro to Golioth**](/docs/golioth-exploration) section
+You must complete the [**Intro to Golioth**](/golioth-exploration) section
 prior to beginning the Zephyr Training module. This module utilizes the device
 you set up during the exploration.
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -24,6 +24,7 @@ const config = {
       /** @type {import('@docusaurus/preset-classic').Options} */
       ({
         docs: {
+          routeBasePath: "/",
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
           //editUrl: 'https://github.com/golioth/developer-training',
@@ -52,19 +53,19 @@ const config = {
         },
         items: [
           {
-            to: 'docs/golioth-exploration',
+            to: 'golioth-exploration',
             activeBasePath: 'golioth-exploration',
             label: 'Intro to Golioth',
             position: 'left',
           },
           {
-            to: 'docs/zephyr-training',
+            to: 'zephyr-training',
             activeBasePath: 'zephyr-training',
             label: 'Zephyr Training',
             position: 'left',
           },
           {
-            to: 'docs/api-training',
+            to: 'api-training',
             activeBasePath: 'api-training',
             label: 'API Training',
             position: 'left',
@@ -106,7 +107,7 @@ const config = {
             items: [
               {
                 label: 'Training Event Code of Conduct',
-                to: '/docs/community/code-of-conduct',
+                to: 'community/code-of-conduct',
               },
               {
                 label: 'Forum',

--- a/website/src/components/HomepageFeatures.js
+++ b/website/src/components/HomepageFeatures.js
@@ -6,7 +6,7 @@ import ThemedImage from '@theme/ThemedImage'
 const FeatureList = [
   {
     title: 'Learn About Golioth',
-    link: '/docs/golioth-exploration',
+    link: 'golioth-exploration',
     img: require('@site/static/img/Golioth_logo_300x300.png').default,
     description: (
       <>
@@ -19,7 +19,7 @@ const FeatureList = [
   },
   {
     title: 'Zephyr Training',
-    link: '/docs/zephyr-training',
+    link: 'zephyr-training',
     img: require('@site/static/img/Zephyr_logo_300x300.png').default,
     description: (
       <>
@@ -33,7 +33,7 @@ const FeatureList = [
   },
   {
     title: 'Golioth REST API Training',
-    link: '/docs/api-training',
+    link: 'api-training',
     description: (
       <>
         Golioth makes it easy to interact with your IoT devices and their data.

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -21,7 +21,7 @@ function HomepageHeader() {
         <div className={styles.buttons}>
           <Link
             className="button button--secondary button--lg"
-            to="/docs/golioth-exploration">
+            to="golioth-exploration">
             Start the {siteConfig.title}!
           </Link>
         </div>


### PR DESCRIPTION
We were prefacing every page with /docs/ as shown here:
```
https://training.golioth.io/docs/golioth-exploration
```
This PR removes the erroneous prefix:
```
https://training.golioth.io/golioth-exploration
```

Firebase 301 redirects are use to make sure existing hard links send the user where they wanted to go.

This change also fixes the top navbar items so they remained highlighted when viewing that module. Resolves #37 