### PR TITLE
Fix 05_golioth main code

### DIFF
--- a/website/docs/zephyr-training/05_golioth/lightdb_stream.md
+++ b/website/docs/zephyr-training/05_golioth/lightdb_stream.md
@@ -82,7 +82,7 @@ Excerpts from `main.c`:
 
         // highlight-start
 		char sbuf[32];
-		snprintk(sbuf, strlen(sbuf), "{\"upcount\":%d}", counter);
+		snprintk(sbuf, sizeof(sbuf), "{\"upcount\":%d}", counter);
 
 		golioth_stream_set_async(client,
 					 "sensor",


### PR DESCRIPTION
Use sizeof(sbuf) as size argument in snprintk() instead of strlen(sbuf).